### PR TITLE
fix(postfix): enforce UI write permissions for config.json on startup

### DIFF
--- a/postfix/entrypoint.sh
+++ b/postfix/entrypoint.sh
@@ -47,8 +47,10 @@ if [ ! -f "$CFG_JSON" ]; then
   "default_from": {}
 }
 EOF
+fi
 
-  # Ensure the UI can update this file later.
+# Ensure the UI can always update this file (covers upgrades from older versions).
+if [ -f "$CFG_JSON" ]; then
   chown "$UI_UID:$UI_GID" "$CFG_JSON" 2>/dev/null || true
   chmod 600 "$CFG_JSON" 2>/dev/null || true
 fi


### PR DESCRIPTION
What changed + why
- Ensures /data/config/config.json is always owned by uid:gid 10001:10001 (the non-root UI user) on postfix container startup.
- This prevents 500 errors when saving onboarding settings on upgrades where config.json was created as root.

How to test
1) Start the stack with an existing volume (or simulate by chowning /data/config/config.json to root).
2) Restart postfix container.
3) Verify config.json becomes 10001:10001 and onboarding step 2 (Save relay settings) returns 200 (no 500).

Risk/impact
- Low. Only adjusts ownership/mode on a single config file in the shared volume.

References
- Fixes #1

— Comment generated by an AI agent