### PR TITLE
Fix: apply config before sending test mail (prevents missing sasl_passwd.lmdb until restart)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1533,6 +1533,7 @@ def testmail(
     require_csrf(request, csrf_token)
     from urllib.parse import quote
 
+    _ensure_applied_best_effort()
     out = send_test_mail(to_addr, from_addr, subject, body)
 
     msg = (out or "ok").strip()
@@ -1544,6 +1545,29 @@ def testmail(
     return RedirectResponse(url=f"/?toast={quote(msg)}&toastLevel={level}#testmail", status_code=303)
 
 
+def _ensure_applied_best_effort() -> str:
+    """Best-effort: ensure Postfix has current config rendered + reloaded.
+
+    Users can run the onboarding test-mail step before hitting Finish.
+    If config changes (e.g. ms365_smtp_user) haven't been applied yet,
+    Postfix may miss generated lmdb maps (e.g. sasl_passwd.lmdb) until a restart.
+
+    Returns a short status string ("ok" or output from render/reload).
+    """
+    try:
+        cfg = load_cfg()
+        current_hash = cfg_hash(cfg)
+        applied_hash = get_applied_hash()
+        pending = (applied_hash is None) or (current_hash != applied_hash)
+        if pending:
+            out = render_and_reload()
+            set_applied_hash(current_hash)
+            return (out or "ok").strip() or "ok"
+    except Exception as e:
+        return f"apply_error:{type(e).__name__}"
+    return "ok"
+
+
 @app.post("/api/testmail")
 def api_testmail(
     to_addr: str = Form(...),
@@ -1551,10 +1575,11 @@ def api_testmail(
     subject: str = Form("Test"),
     body: str = Form("Does it work?"),
 ):
+    apply_out = _ensure_applied_best_effort()
     out = send_test_mail(to_addr, from_addr, subject, body)
     msg = (out or "ok").strip() or "ok"
-    level = "error" if "exit" in msg.lower() else "ok"
-    return {"ok": True, "output": msg, "level": level}
+    level = "error" if ("exit" in msg.lower() or "apply_error" in apply_out.lower()) else "ok"
+    return {"ok": True, "output": msg, "level": level, "apply": apply_out}
 
 
 @app.get("/api/status")


### PR DESCRIPTION
Issue #8 indicates test mail can fail until a container restart. Likely cause: onboarding test-mail step can be run before Finish/apply, so Postfix still uses old config and may miss generated lmdb maps (e.g. sasl_passwd.lmdb).

This PR makes /api/testmail (and the HTML fallback) best-effort apply pending config (render+reload) before sending.

Fixes #8.

— Comment generated by an AI agent
