### PR TITLE
Fix placeholder formatting in from_addr textarea

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1752,7 +1752,8 @@
               <div class="text-sm font-semibold">Add allowed From</div>
               <div class="text-xs text-slate-500 dark:text-slate-400">Tip: submit the same login again to add more From addresses.</div>
               <input name="login" placeholder="login" class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none dark:border-slate-800 dark:bg-slate-900" />
-              <textarea name="from_addr" rows="3" placeholder="from1@example.com\nfrom2@example.com" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none dark:border-slate-800 dark:bg-slate-900"></textarea>
+              <textarea name="from_addr" rows="3" placeholder="from1@example.com
+                from2@example.com" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none dark:border-slate-800 dark:bg-slate-900"></textarea>
               <div class="text-xs text-slate-500 dark:text-slate-400">Enter one address per line (or comma/space separated).</div>
               <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500">
                 <i data-lucide="plus" class="h-4 w-4"></i>


### PR DESCRIPTION
Fixes the visual "new line(\n)" bug in the ui

<img width="456" height="306" alt="image" src="https://github.com/user-attachments/assets/6bde4de4-a25a-4506-bfb6-d08f6db0af42" />
