### PR TITLE
Fix: Test mail output should not show false "OK" (queue id + better status)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1535,7 +1535,7 @@ def testmail(
 
     out = send_test_mail(to_addr, from_addr, subject, body)
 
-    msg = (out or "ok").strip()
+    msg = (out or "queued").strip()
     if len(msg) > 600:
         msg = msg[:600] + "…"
 
@@ -1552,9 +1552,16 @@ def api_testmail(
     body: str = Form("Does it work?"),
 ):
     out = send_test_mail(to_addr, from_addr, subject, body)
-    msg = (out or "ok").strip() or "ok"
-    level = "error" if "exit" in msg.lower() else "ok"
-    return {"ok": True, "output": msg, "level": level}
+    msg = (out or "").strip()
+
+    ok = True
+    if not msg:
+        msg = "queued"
+    if "sendmail exit" in msg.lower() or "error" in msg.lower():
+        ok = False
+
+    level = "ok" if ok else "error"
+    return {"ok": ok, "output": msg, "level": level, "note": "OK means queued/accepted locally; check Mail Log / queue for delivery."}
 
 
 @app.get("/api/status")

--- a/postfix/control.py
+++ b/postfix/control.py
@@ -236,8 +236,9 @@ def send_test_mail(to_addr: str, from_addr: str, subject: str, body: str) -> str
         f"{body}\n"
     )
 
+    # Use -v to surface queue id / immediate SMTP dialogue where available.
     p = subprocess.run(
-        ["/usr/sbin/sendmail", "-t", "-f", from_addr],
+        ["/usr/sbin/sendmail", "-v", "-t", "-f", from_addr],
         input=msg,
         text=True,
         stdout=subprocess.PIPE,
@@ -246,7 +247,9 @@ def send_test_mail(to_addr: str, from_addr: str, subject: str, body: str) -> str
     out = (p.stdout or "").strip()
     if p.returncode != 0:
         return f"sendmail exit {p.returncode}\n" + out
-    return out or "ok"
+    # NOTE: returncode=0 only means the message was accepted/queued locally,
+    # not that it has been delivered to Microsoft 365.
+    return out or "queued"
 
 
 def _append_log(path: Path, text: str, max_bytes: int = 200_000) -> None:


### PR DESCRIPTION
Improves test-mail reporting:

- postfix: run sendmail with -v so the output includes queue id / dialogue where available
- ui: /api/testmail returns ok=false for sendmail failures, and labels success as queued/accepted (not delivered)

Fixes #8 (reporting part).

— Comment generated by an AI agent
