### PR TITLE
fix(issue-8): apply-before-testmail + improved reporting

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1536,7 +1536,7 @@ def testmail(
     _ensure_applied_best_effort()
     out = send_test_mail(to_addr, from_addr, subject, body)
 
-    msg = (out or "ok").strip()
+    msg = (out or "queued").strip()
     if len(msg) > 600:
         msg = msg[:600] + "…"
 
@@ -1577,9 +1577,23 @@ def api_testmail(
 ):
     apply_out = _ensure_applied_best_effort()
     out = send_test_mail(to_addr, from_addr, subject, body)
-    msg = (out or "ok").strip() or "ok"
-    level = "error" if ("exit" in msg.lower() or "apply_error" in apply_out.lower()) else "ok"
-    return {"ok": True, "output": msg, "level": level, "apply": apply_out}
+
+    msg = (out or "").strip()
+
+    ok = True
+    if not msg:
+        msg = "queued"
+    if ("sendmail exit" in msg.lower()) or ("error" in msg.lower()) or ("apply_error" in apply_out.lower()):
+        ok = False
+
+    level = "ok" if ok else "error"
+    return {
+        "ok": ok,
+        "output": msg,
+        "level": level,
+        "apply": apply_out,
+        "note": "OK means queued/accepted locally; check Mail Log / queue for delivery.",
+    }
 
 
 @app.get("/api/status")

--- a/postfix/control.py
+++ b/postfix/control.py
@@ -236,8 +236,9 @@ def send_test_mail(to_addr: str, from_addr: str, subject: str, body: str) -> str
         f"{body}\n"
     )
 
+    # Use -v to surface queue id / immediate SMTP dialogue where available.
     p = subprocess.run(
-        ["/usr/sbin/sendmail", "-t", "-f", from_addr],
+        ["/usr/sbin/sendmail", "-v", "-t", "-f", from_addr],
         input=msg,
         text=True,
         stdout=subprocess.PIPE,
@@ -246,7 +247,9 @@ def send_test_mail(to_addr: str, from_addr: str, subject: str, body: str) -> str
     out = (p.stdout or "").strip()
     if p.returncode != 0:
         return f"sendmail exit {p.returncode}\n" + out
-    return out or "ok"
+    # NOTE: returncode=0 only means the message was accepted/queued locally,
+    # not that it has been delivered to Microsoft 365.
+    return out or "queued"
 
 
 def _append_log(path: Path, text: str, max_bytes: int = 200_000) -> None:


### PR DESCRIPTION
Consolidates the two issue-#8 fixes:
- apply config before test mail (avoids missing lmdb maps / reload gap)
- improved test mail reporting (no false OK; adds guidance)

Verified locally with a clean dev volume:
- Saved settings via /api/settings without manually applying
- /api/testmail auto-applies and the message is delivered (status=sent) when a valid token exists.

— Comment generated by an AI agent
