### PR TITLE
fix(ui): multiline placeholder without whitespace (&#10;)

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1752,7 +1752,7 @@
               <div class="text-sm font-semibold">Add allowed From</div>
               <div class="text-xs text-slate-500 dark:text-slate-400">Tip: submit the same login again to add more From addresses.</div>
               <input name="login" placeholder="login" class="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none dark:border-slate-800 dark:bg-slate-900" />
-              <textarea name="from_addr" rows="3" placeholder="from1@example.com\nfrom2@example.com" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none dark:border-slate-800 dark:bg-slate-900"></textarea>
+              <textarea name="from_addr" rows="3" placeholder="from1@example.com&#10;from2@example.com" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none dark:border-slate-800 dark:bg-slate-900"></textarea>
               <div class="text-xs text-slate-500 dark:text-slate-400">Enter one address per line (or comma/space separated).</div>
               <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500">
                 <i data-lucide="plus" class="h-4 w-4"></i>


### PR DESCRIPTION
Follow-up / alternative implementation for PR #10.

Uses an HTML entity (`&#10;`) for a multi-line `<textarea placeholder>` so the second line doesn’t get leading spaces from HTML indentation.

How to verify:
- Go to Dashboard → Allowed From addresses → “Add allowed From”
- Confirm placeholder shows two lines with no leading spaces on line 2.

— Comment generated by an AI agent
